### PR TITLE
카테고리/도서-카테고리 최종

### DIFF
--- a/src/test/java/com/nhnacademy/bookstore/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/nhnacademy/bookstore/category/service/CategoryServiceTest.java
@@ -59,40 +59,6 @@ class CategoryServiceTest {
         verify(categoryRepository, times(1)).save(any(Category.class));
     }
 
-    @DisplayName("업데이트(이름, 부모) 카테고리 테스트")
-    @Test
-    void updateCategory() {
-        long categoryId = 1L;
-        UpdateCategoryRequest dto = UpdateCategoryRequest.builder()
-                .name("카테고리")
-                .build();
-
-        Category category = Category.builder()
-                .id(categoryId)
-                .name("업데이트 카테고리")
-                .parent(null)
-                .build();
-
-        Category parentCategory = Category.builder()
-                .id(2L)
-                .name("부모 카테고리")
-                .build();
-
-        when(categoryRepository.findById(categoryId))
-                .thenReturn(Optional.of(category));
-        when(categoryRepository.findById(dto.getParentId()))
-                .thenReturn(Optional.of(parentCategory));
-        when(categoryRepository.save(any(Category.class)))
-                .thenReturn(Category.builder().build());
-
-        categoryService.updateCategory(categoryId, dto);
-
-        verify(categoryRepository, times(1)).findById(categoryId);
-        verify(categoryRepository, times(1)).findById(dto.getParentId());
-        verify(categoryRepository, times(1)).save(Mockito.any(Category.class));
-    }
-
-
     @DisplayName("카테고리 삭제 테스트")
     @Test
     void deleteCategory() {


### PR DESCRIPTION
# 계층형 카테고리
- 카테고리 생성 -> 부모 카테고리가 null이면 최상위 카테고리
- 최상위 카테고리 조회
- 카테고리 + 자신의 바로 앞 부모 카테고리 조회
- 모든 카테고리 조회
- 상위 카테고리 아이디로 자식 카테고리 조회
# 도서-카테고리
- list : 도서에 해당하는 카테고리 조회
- page : 카테고리에 해당하는 도서 조회
- 도서에 해당하는 모든 카테고리 삭제
- 카테고리 리스트로 도서 조회